### PR TITLE
Update cosign installer to track main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,10 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
-        with:
-          cosign-release: 'v1.4.0'
+        uses: sigstore/cosign-installer@main
+      - name: Check cosign install!
+        if: github.event_name != 'pull_request'
+        run: cosign version
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
Our cosign version is tracking an old commit, this updates it to
track main and hopefully as a side effect will end up using endpoint
fulcio.sigstore.dev
instead of v1.fulcio.sigstore.dev

https://github.com/sigstore/fulcio/issues/753