### PR TITLE
Add support for arm64 container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,8 @@ jobs:
         if: github.event_name != 'pull_request'
         run: cosign version
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -83,6 +85,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
Test plan:
After merging https://github.com/chantra/runner/pull/2 and having https://github.com/chantra/runner/actions/runs/3185139746 build and publish the container, https://github.com/chantra/runner/pkgs/container/runner/44341109?tag=staging shows both arm64 and amd64 as available architectures.

Then I could download the runner, run it, and attach it as a runner of https://github.com/chantra/gh_runner_tests/

Finally, I could schedule a job: https://github.com/chantra/gh_runner_tests/actions/runs/3161797207/jobs/5194792546

```
[ec2-user@ip-10-0-3-73 runner]$ sudo docker run -ti ghcr.io/chantra/runner:staging bash
root@152208d8dd90:/actions-runner# ./config.sh --url https://github.com/chantra/gh_runner_tests --token <token_here>

--------------------------------------------------------------------------------
|        ____ _ _   _   _       _          _        _   _                      |
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      |
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     |
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     |
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     |
|                                                                              |
|                       Self-hosted runner registration                        |
|                                                                              |
--------------------------------------------------------------------------------

√ Connected to GitHub

Enter the name of the runner group to add this runner to: [press Enter for Default]

Enter the name of runner: [press Enter for 152208d8dd90]

This runner will have the following labels: 'self-hosted', 'Linux', 'ARM64'
Enter any additional labels (ex. label-1,label-2): [press Enter to skip] ubuntu-latest

√ Runner successfully added
√ Runner connection is good

Enter name of work folder: [press Enter for _work]

√ Settings Saved.

root@152208d8dd90:/actions-runner# ./run.sh

√ Connected to GitHub

Current runner version: '2.298.2'
2022-10-04 20:44:38Z: Listening for Jobs
2022-10-04 20:44:53Z: Running job: my-job
2022-10-04 20:44:57Z: Job my-job completed with result: Succeeded
^CExiting...
Runner listener exit with 0 return code, stop the service, no retry needed.
Exiting runner...
root@152208d8dd90:/actions-runner# uname -a
Linux 152208d8dd90 5.10.135-122.509.amzn2.aarch64 #1 SMP Thu Aug 11 22:41:14 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
```