### PR TITLE
Add LLVM repo in a separate file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
   && apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils \
   && apt-get install -y g++ libelf-dev \
   && apt-get install -y iproute2 iputils-ping \
-  && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list \
+  && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" > /etc/apt/sources.list.d/llvm.list \
   && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
   && apt-get update \
   && apt-get install -y clang lld llvm


### PR DESCRIPTION
Put the repository in /etc/apt/sources.list.d/llvm.list instead of appending it to /etc/apt/sources.list.
This avoid having the repository duplicated multiple times.