### PR TITLE
Build s390x runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
 
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push s390x Docker image
+        id: build-and-push-s390x
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: s390x.Dockerfile
+          platforms: linux/s390x
+
+
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,17 +51,16 @@ jobs:
         run: cosign version
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -71,7 +70,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -79,7 +78,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -91,7 +90,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push s390x Docker image
         id: build-and-push-s390x
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -1,0 +1,66 @@
+# Self-Hosted IBM Z Github Actions Runner.
+
+# Temporary image: amd64 dependencies.
+FROM amd64/ubuntu:20.04 as ld-prefix
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install ca-certificates libicu66 libssl1.1
+
+# Main image.
+FROM s390x/ubuntu:20.04
+
+# Packages for libbpf testing that are not installed by .github/actions/setup.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install \
+        bc \
+        bison \
+        cmake \
+        cpu-checker \
+        curl \
+        dumb-init \
+        wget \
+        flex \
+        git \
+        jq \
+        linux-image-generic \
+        qemu-system-s390x \
+        rsync \
+        software-properties-common \
+        sudo \
+        tree \
+        zstd \
+        iproute2 \
+        iputils-ping
+
+# amd64 Github Actions Runner.
+ARG version=2.299.1
+ARG homedir=/actions-runner
+# Copy scripts from  myoung34/docker-github-actions-runner
+RUN curl -L https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${version}/entrypoint.sh -o /entrypoint.sh && chmod 755 /entrypoint.sh
+RUN curl -L https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${version}/token.sh -o /token.sh && chmod 755 /token.sh
+
+RUN useradd -d ${homedir} -m runner
+RUN echo "runner ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
+RUN echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >>/etc/sudoers
+# Make sure kvm group exists. This is a no-op when it does.
+RUN addgroup --system kvm
+RUN usermod -a -G kvm runner
+USER runner
+ENV USER=runner
+WORKDIR ${homedir}
+RUN curl -L https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-x64-${version}.tar.gz | tar -xz
+USER root
+
+VOLUME ${homedir}
+
+# WARNING: This needs to be set at the end of the file or it will have side effects when building the container
+# from within a foreign arch (like building on x86 host).
+# amd64 dependencies.
+# More specifically this is setting QEMU_LD_PREFIX that causes issue, but before touching system
+# files, we may as well finish any prior installs.
+COPY --from=ld-prefix / /usr/x86_64-linux-gnu/
+RUN ln -fs ../lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/x86_64-linux-gnu/lib64/
+RUN ln -fs /etc/resolv.conf /usr/x86_64-linux-gnu/etc/
+ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]


### PR DESCRIPTION
This change allows building and publishing s390x runners directly from this repo.

This has the advantage that:
- all the architectures that are running our runners will be able to pull the runner in a consistent manner.
- s390x runners, will not need to build the runners locally anymore.
- The CI will take care of updating the runner daily.
- Updating the version of the runner will be a matter of updating the version in s390x.Dockerfile

The only con so far is that there may be a window of time when the s390x build is not available right after the x86_64/arm64's new containers are available. Essentially a matter of 10 min or so.

During that time, the runners will still ave an old version of the runners available locally. It is realistically only a problem when a new host is provisioned, which is a fair price to pay.