### PR TITLE
build s390x containers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,17 +63,16 @@ jobs:
         run: cosign version
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -83,7 +82,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -95,7 +94,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,18 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
+    strategy:
+      matrix:
+        include:
+          - arch: s390x
+            dockerfile: s390x.Dockerfile
+            platform: linux/s390x
+          - arch: aarch64
+            dockerfile: Dockerfile
+            platform: linux/arm64
+          - arch: x86_64
+            dockerfile: Dockerfile
+            platform: linux/amd64
 
     steps:
       - name: Checkout repository
@@ -74,6 +86,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=-${{ matrix.arch }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -82,10 +98,11 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -1,0 +1,66 @@
+# Self-Hosted IBM Z Github Actions Runner.
+
+# Temporary image: amd64 dependencies.
+FROM amd64/ubuntu:20.04 as ld-prefix
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install ca-certificates libicu66 libssl1.1
+
+# Main image.
+FROM s390x/ubuntu:20.04
+
+# Packages for libbpf testing that are not installed by .github/actions/setup.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install \
+        bc \
+        bison \
+        cmake \
+        cpu-checker \
+        curl \
+        dumb-init \
+        wget \
+        flex \
+        git \
+        jq \
+        linux-image-generic \
+        qemu-system-s390x \
+        rsync \
+        software-properties-common \
+        sudo \
+        tree \
+        zstd \
+        iproute2 \
+        iputils-ping
+
+# amd64 Github Actions Runner.
+ARG version=2.299.1
+ARG homedir=/actions-runner
+# Copy scripts from  myoung34/docker-github-actions-runner
+RUN curl -L https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${version}/entrypoint.sh -o /entrypoint.sh && chmod 755 /entrypoint.sh
+RUN curl -L https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${version}/token.sh -o /token.sh && chmod 755 /token.sh
+
+RUN useradd -d ${homedir} -m runner
+RUN echo "runner ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers
+RUN echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >>/etc/sudoers
+# Make sure kvm group exists. This is a no-op when it does.
+RUN addgroup --system kvm
+RUN usermod -a -G kvm runner
+USER runner
+ENV USER=runner
+WORKDIR ${homedir}
+RUN curl -L https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-x64-${version}.tar.gz | tar -xz
+USER root
+
+VOLUME ${homedir}
+
+# WARNING: This needs to be set at the end of the file or it will have side effects when building the container
+# from within a foreign arch (like building on x86 host).
+# amd64 dependencies.
+# More specifically this is setting QEMU_LD_PREFIX that causes issue, but before touching system
+# files, we may as well finish any prior installs.
+COPY --from=ld-prefix / /usr/x86_64-linux-gnu/
+RUN ln -fs ../lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/x86_64-linux-gnu/lib64/
+RUN ln -fs /etc/resolv.conf /usr/x86_64-linux-gnu/etc/
+ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]


### PR DESCRIPTION
This change will build the s390x containers alongside the arm64 and amd64 ones.

Becuase s390x dockerfile is different than the ones for arm64/amd64, we can't generate a multi-arch container with the same tag (say `main`) in 1 step. Having the 2 steps causes the latest step to nuke the tag for the archs from the first step, making  the container unavailable for that arch, which is how we ended up reverting the first attempt to build s390x containers: 4f09482052c1df07aa46586098ce83ace1c8bfe6

For this reason, we are now creating a tag for every single arch in the form `{arch}-{tag}`, e.g `s390x-main`. This also allows us to build the 3 archs in parallel as they are all independent steps.
A separate libbpf/ci diff will be needed to get runners to pick up the new tag.