### PR TITLE
s390x: remove the volume

### DIFF
--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -50,8 +50,6 @@ WORKDIR ${homedir}
 RUN curl -L https://github.com/actions/runner/releases/download/v${version}/actions-runner-linux-x64-${version}.tar.gz | tar -xz
 USER root
 
-VOLUME ${homedir}
-
 # WARNING: This needs to be set at the end of the file or it will have side effects when building the container
 # from within a foreign arch (like building on x86 host).
 # amd64 dependencies.


### PR DESCRIPTION
Volumes get created and deleted each time the container restart. the non-s390x containers do not have this volume, so let's uniformize this bit too.

We could benefit from volumes to keep the logs generated by the actions-runner, but this would be done by using a consitent volume across restarts (as opposed to new anonymous volume on each restarts).