### PR TITLE
Force v2.301.1 to work around myoung34/docker-github-actions-runner#277

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # hadolint ignore=DL3007
-FROM myoung34/github-runner:latest
+FROM myoung34/github-runner:2.301.1
 LABEL maintainer="sunyucong@gmail.com"
 
 RUN apt-get update \


### PR DESCRIPTION
It seems that GH is sometime generating new release event for older releases: https://github.com/orgs/community/discussions/12225

this causes older releases to be marked as latest and break our runners:

https://github.com/myoung34/docker-github-actions-runner/issues/277