### PR TITLE
Add `--yes` to `cosign sign` command line.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,4 +116,4 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: cosign sign ${TAGS}
+        run: cosign sign --yes ${TAGS}


### PR DESCRIPTION
Our runs started to fail with https://gist.github.com/chantra/6ba6cdc65bd462bf082e8d8d0d91d02a

This is similar to https://github.com/sigstore/cosign-installer/pull/110