### PR TITLE
[s390x] Add python3 to the base container

### DIFF
--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get -y install \
         git \
         jq \
         linux-image-generic \
+        python3 \
         qemu-system-s390x \
         rsync \
         software-properties-common \


### PR DESCRIPTION
Since kernel-patches/vmtest#219 we can run a python script on any self-hosted machine.
In
https://github.com/kernel-patches/bpf/actions/runs/4812178631/jobs/8567081936, the job was ran on a s390x machine and failed with the error:
```
  Error: python3: command not found
```

this change ensure that `python3` is installed (which is the case for standard runners:
https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md )