### PR TITLE
pkg: add a few packages that we will depend on during testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
   && apt-get install -y cmake flex bison build-essential libssl-dev ncurses-dev xz-utils bc rsync libguestfs-tools qemu-kvm qemu-utils linux-image-generic zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils \
   && apt-get install -y g++ libelf-dev \
   && apt-get install -y iproute2 iputils-ping \
+  && apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent ethtool keyutils iptables gawk \
   && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" > /etc/apt/sources.list.d/llvm.list \
   && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
   && apt-get update \

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -23,14 +23,14 @@ RUN apt-get update && apt-get -y install \
         jq \
         linux-image-generic \
         python3 \
-        qemu-system-s390x \
         rsync \
         software-properties-common \
         sudo \
         tree \
         zstd \
         iproute2 \
-        iputils-ping
+        iputils-ping && \
+    apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent ethtool keyutils iptables gawk
 
 # amd64 Github Actions Runner.
 ARG version=2.311.0


### PR DESCRIPTION
We will end up installing those later, but can save a bit of time by installing them when the containers are built.
At run time, we will detect if they need to be updated and install them then.