### PR TITLE
runners: Use ubuntu version as an argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # hadolint ignore=DL3007
-FROM myoung34/github-runner:latest
+ARG UBUNTU_VERSION=focal
+FROM myoung34/github-runner:ubuntu-${UBUNTU_VERSION}
 LABEL maintainer="sunyucong@gmail.com"
 
 RUN apt-get update \
@@ -7,7 +8,7 @@ RUN apt-get update \
   && apt-get install -y g++ libelf-dev \
   && apt-get install -y iproute2 iputils-ping \
   && apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent ethtool keyutils iptables gawk \
-  && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" > /etc/apt/sources.list.d/llvm.list \
+  && echo "deb https://apt.llvm.org/${UBUNTU_VERSION}/ llvm-toolchain-${UBUNTU_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
   && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
   && apt-get update \
   && apt-get install -y clang lld llvm

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -1,12 +1,12 @@
 # Self-Hosted IBM Z Github Actions Runner.
-
+ARG UBUNTU_VERSION=focal
 # Temporary image: amd64 dependencies.
-FROM amd64/ubuntu:20.04 as ld-prefix
+FROM amd64/ubuntu:${UBUNTU_VERSION} as ld-prefix
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install ca-certificates libicu66 libssl1.1
 
 # Main image.
-FROM s390x/ubuntu:20.04
+FROM s390x/ubuntu:${UBUNTU_VERSION}
 
 # Packages for libbpf testing that are not installed by .github/actions/setup.
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Instead of hardcoding version 20.04, use the argument UBUNTU_VERSION and default to "focal" (e.g 20.04). All depedencies accept both 20.04 and focal as a tag to the same container.