### PR TITLE
Revert "[automated] Bumping s390x containers to action-runners v2.321.0"

### DIFF
--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get -y install \
     apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent ethtool keyutils iptables gawk
 
 # amd64 Github Actions Runner.
-ARG version=2.321.0
+ARG version=2.320.0
 ARG homedir=/actions-runner
 # Copy scripts from  myoung34/docker-github-actions-runner
 RUN curl -L https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${version}/entrypoint.sh -o /entrypoint.sh && chmod 755 /entrypoint.sh


### PR DESCRIPTION
This reverts commit b2a8dc58053b2fc9f47f73336c2a9f13db3d6adb.

s390x runners v2.321.0 crash with segfault on entrypoint.

Reverting to unblock the runners...