### PR TITLE
s390x: set DOTNET_EnableWriteXorExecute=0

### DIFF
--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get -y install \
     apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent ethtool keyutils iptables gawk
 
 # amd64 Github Actions Runner.
-ARG version=2.320.0
+ARG version=2.321.0
 ARG homedir=/actions-runner
 # Copy scripts from  myoung34/docker-github-actions-runner
 RUN curl -L https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${version}/entrypoint.sh -o /entrypoint.sh && chmod 755 /entrypoint.sh
@@ -62,6 +62,9 @@ COPY --from=ld-prefix / /usr/x86_64-linux-gnu/
 RUN ln -fs ../lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/x86_64-linux-gnu/lib64/
 RUN ln -fs /etc/resolv.conf /usr/x86_64-linux-gnu/etc/
 ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
+# mitigates .NET 8 crash in qemu emulation
+# see https://gitlab.com/qemu-project/qemu/-/issues/2600
+ENV DOTNET_EnableWriteXorExecute=0
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]


### PR DESCRIPTION
Github Actions Runner.Listener x86_64 binary version 2.321.0 has been crashing with segfault on startup when emulated on s390x [1].

Ilya pointed out, that the root cause of this crash is most likely a qemu issue [2].

.NET 8 turns on "write xor execute" feature [3] by default. And GH actions runner 2.320.0->2.321.0 update includes an upgrade to .NET 8 [4].

Ilya suggested opting out of this feature in our environment to mitigate the failure.

I tested this with manually built runner immage on one for s390x BPF CI hosts: the runner doesn't crash.

[1] https://github.com/actions/runner/issues/3583
[2] https://gitlab.com/qemu-project/qemu/-/issues/2600 [3]
https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/#runtime:-w^x-(write-xor-execute)-support-for-all-platforms-and-architectures [4] https://github.com/actions/runner/pull/3500

Suggested-by: Ilya Leoshkevich <iii@linux.ibm.com>