### PR TITLE
Revert "[automated] s390x: bump RUNNER_VERSION to v2.323.0"

### DIFF
--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -1,6 +1,6 @@
 # Self-Hosted IBM Z Github Actions Runner
 
-ARG RUNNER_VERSION=2.323.0
+ARG RUNNER_VERSION=2.322.0
 
 FROM ubuntu:noble AS build-s390x-runner-binaries
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
s390x runners fail to start with:
```
exec /entrypoint.sh: exec format error
```

Needs investigation.