### PR TITLE
Exit with special status code in token.sh on error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ RUN apt-get update -y && apt-get install -y \
 # Install LLVM with automatic script (https://apt.llvm.org)
 RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
+COPY token.sh /token.sh
+
 RUN apt-get clean

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -64,7 +64,9 @@ RUN apt-get clean
 
 # Copy scripts from myoung34/docker-github-actions-runner
 RUN curl -Lf https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${RUNNER_VERSION}/entrypoint.sh -o /entrypoint.sh && chmod 755 /entrypoint.sh
-RUN curl -Lf https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${RUNNER_VERSION}/token.sh -o /token.sh && chmod 755 /token.sh
+
+# RUN curl -Lf https://raw.githubusercontent.com/myoung34/docker-github-actions-runner/${RUNNER_VERSION}/token.sh -o /token.sh && chmod 755 /token.sh
+COPY token.sh /token.sh
 
 RUN useradd -d ${RUNNER_HOME} -m runner
 RUN echo "runner ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers

--- a/token.sh
+++ b/token.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script was copied from https://github.com/myoung34/docker-github-actions-runner/blob/2.323.0/token.sh
+# The customization is in handling an empty RUNNER_TOKEN error with exit 199, which is picked up by systemd service.
+
+_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+
+# If URL is not github.com then use the enterprise api endpoint
+if [[ ${GITHUB_HOST} = "github.com" ]]; then
+  URI="https://api.${_GITHUB_HOST}"
+else
+  URI="https://${_GITHUB_HOST}/api/v3"
+fi
+
+API_VERSION=v3
+API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
+AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
+CONTENT_LENGTH_HEADER="Content-Length: 0"
+
+case ${RUNNER_SCOPE} in
+  org*)
+    _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners/registration-token"
+    ;;
+
+  ent*)
+    _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners/registration-token"
+    ;;
+
+  *)
+    _PROTO="https://"
+    # shellcheck disable=SC2116
+    _URL="$(echo "${REPO_URL/${_PROTO}/}")"
+    _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+    _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
+    _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+    _FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners/registration-token"
+    ;;
+esac
+
+RUNNER_TOKEN="$(curl -XPOST -fsSL \
+  -H "${CONTENT_LENGTH_HEADER}" \
+  -H "${AUTH_HEADER}" \
+  -H "${API_HEADER}" \
+  "${_FULL_URL}" \
+| jq -r '.token')"
+
+if [ -z "${RUNNER_TOKEN}" ]; then
+    echo "token.sh: GitHub has not issued an access token!" 1>&2
+    exit 199
+fi
+
+echo "{\"token\": \"${RUNNER_TOKEN}\", \"full_url\": \"${_FULL_URL}\"}"


### PR DESCRIPTION
Add a check for an empty response when requesting an access token on runner startup. If no token was recieved, exit with status 199, which then can be picked up by systemd instructing it to not restart the runner container.

BPF CI runners went down recently due to the following problem:

  * For some runners, after successful authentication, on attempt to recieve a job the runner app gets "Runner not found" error, which appears to be an error returned from github broker service [1].

  * The systemd service maintaining the runner container automatically restarts it, leading to a frequent error -> restart loop.

  * Each time container starts, the token.sh script [2] requests a runner-specific github access token. However there is a 5k/hour limit for such requests [3].

  * Because there are dozens of runners we run out of tokens in minutes which effectively disables healthy runners too.

This token.sh customization will make sure that the runners affected by this (or similar) issue don't also break healthy runners for more than an hour.

[1] https://github.com/actions/runner/issues/3857
[2] https://github.com/myoung34/docker-github-actions-runner/blob/2.323.0/token.sh
[3] https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users