### PR TITLE
Cache libbpf/ci dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,10 @@ FROM myoung34/github-runner:ubuntu-${UBUNTU_VERSION}
 # Redefining UBUNTU_VERSION without a value inherits the global default
 ARG UBUNTU_VERSION
 
-LABEL maintainer="sunyucong@gmail.com"
+COPY install-dependencies.sh /tmp/install-dependencies.sh
+RUN /tmp/install-dependencies.sh
 
-RUN apt-get update -y && apt-get install -y \
-    bc bison build-essential cmake cpu-checker curl dumb-init elfutils ethtool flex g++ gawk git \
-    iproute2 iptables iputils-ping jq keyutils libguestfs-tools python3-minimal python3-docutils \
-    rsync software-properties-common sudo tree wget xz-utils zstd
-
-RUN apt-get update -y && apt-get install -y \
-    binutils-dev libcap-dev libdw-dev libelf-dev libssl-dev ncurses-dev
-
-RUN apt-get update -y && apt-get install -y \
-    qemu-guest-agent qemu-kvm qemu-system-arm qemu-system-s390x qemu-system-x86 qemu-utils
-
-# Install LLVM with automatic script (https://apt.llvm.org)
-RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+RUN apt-get clean
 
 COPY token.sh /token.sh
 
-RUN apt-get clean

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# runner
+# BPF CI self-hosted Github Actions runners
 
-This repo is for building runner image based on myoung34/github-runner:latest, preloading a bunch of apt-get installs to save time on all CI runs.
+This repository contains code to build and push docker images for BPF
+CI self-hosted action runners.
+
+The main image is based on https://github.com/myoung34/docker-github-actions-runner
+
+The s390x image is custom: it uses code from
+https://github.com/ppc64le/gaplib to build s390x binary of the
+https://github.com/actions/runner, because s390x is not a platform
+officially supported by github actions.
+
+---
+
+Other BPF CI repositories:
+* https://github.com/kernel-patches/bpf
+* https://github.com/kernel-patches/vmtest
+* https://github.com/kernel-patches/kernel-patches-daemon
+* https://github.com/libbpf/ci

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Most of the BPF CI dependencies are set up by libbpf/ci/setup-build-env action
+# This script runs a subset of it, in order to cache the packages at image build time
+export LIBBPF_CI_TAG=v3
+
+# These should correspond to https://github.com/kernel-patches/vmtest/blob/master/.github/scripts/matrix.py#L20-L21
+# Otherwise there is no point in caching dependencies in the image
+export GCC_VERSION=14
+export LLVM_VERSION=20
+
+scratch=$(mktemp -d)
+cd $scratch
+
+git clone --depth 1 --branch $LIBBPF_CI_TAG https://github.com/libbpf/ci.git actions
+cd actions
+./setup-build-env/install_packages.sh
+./setup-build-env/install_clang.sh
+./run-vmtest/install-dependencies.sh
+
+# do not install pahole and cross-compilation toolchain in the docker image

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -19,8 +19,6 @@ RUN apt-get -y install dotnet-sdk-8.0
 RUN git clone ${S390X_RUNNER_REPO} /opt/s390x-runner
 WORKDIR /opt/s390x-runner
 RUN git checkout ${S390X_RUNNER_REPO_REV}
-# RUN cp build-files/99synaptics /etc/apt/apt.conf.d/
-# RUN cp build-files/01-nodoc /etc/dpkg/dpkg.cfg.d/
 RUN cp ${S390X_PATCH} /opt/runner.patch
 COPY 0001-Fix-TestRunnerJobRequestMessageFromRunService_AuthMi.patch /opt/test.patch
 
@@ -49,18 +47,11 @@ ARG RUNNER_HOME=/actions-runner
 ARG RUNNER_VERSION
 
 RUN apt-get update -y
-RUN apt-get install -y \
-    bc bison build-essential cmake cpu-checker curl dumb-init elfutils ethtool flex g++ gawk git \
-    iproute2 iptables iputils-ping jq keyutils libguestfs-tools python3-minimal python3-docutils \
-    rsync software-properties-common sudo tree wget xz-utils zstd
-RUN apt-get install -y \
-    binutils-dev libcap-dev libdw-dev libelf-dev libssl-dev ncurses-dev
-RUN apt-get install -y \
-    qemu-guest-agent qemu-kvm qemu-system-arm qemu-system-s390x qemu-system-x86 qemu-utils
-RUN apt-get install -y aspnetcore-runtime-8.0
+RUN apt-get -y install curl dumb-init git gnupg lsb-release software-properties-common sudo wget
+COPY install-dependencies.sh /tmp/install-dependencies.sh
+RUN /tmp/install-dependencies.sh
 
-# Install LLVM with automatic script (https://apt.llvm.org)
-RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+RUN apt-get -y install aspnetcore-runtime-8.0
 
 RUN apt-get clean
 


### PR DESCRIPTION
BPF CI uses various actions from libbpf/ci repo. Many of them have
system package dependencies and usually action code installs what it
needs itself.

Our self-hosted runners are docker containers. We can take advantage
of the fact that we control the docker image and pre-install common
dependencies in the image, effectively caching them.

So far this was done by hardcoding a list of some packages in
dockerfiles. A better approach is to install exactly the same packages
as libbpf/ci actions.

The first attempt to do this [1] failed, because it turned out some
dependencies (such as iproute2 needed for some BPF selftest) were only
installed in the dockerfile, and not by a relevant action.
Additionally s390x image broke because of missing dumb-init for a
similar reason.

Now that libbpf/ci part of these issues is fixed [2], let's update the
dockerfiles.

[1] https://github.com/kernel-patches/runner/pull/78
[2] https://github.com/libbpf/ci/pull/186