### PR TITLE
kbuilder-debian: switch to experimental release

### DIFF
--- a/kbuilder-debian.Dockerfile
+++ b/kbuilder-debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:experimental
 
 ARG RUNNER_VERSION=2.331.0
 ARG LIBBPF_CI_TAG=v4


### PR DESCRIPTION
testing is currently broken due to a lag in package version updates between s390x and amd64, causing cross-compilation toolchain installation failures [1].

[1] https://github.com/kernel-patches/bpf/actions/runs/25156859022/job/73740909378